### PR TITLE
Prevent ls complaining about missing folders

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -151,7 +151,7 @@ checkJarsPalettes()
 BW_VERSION=`ls $HOME/tibco.home/bw*/`
 
 pluginFolder=/resources/addons/plugins
-if [ "$(ls $pluginFolder)"  ]; then 
+if [ -d $pluginFolder ] && [ "$(ls $pluginFolder)" ]; then 
 	print_Debug "Adding Plug-in Jars"
 	echo -e "name=Addons Factory\ntype=bw6\nlayout=bw6ext\nlocation=$HOME/tibco.home/addons" > `echo $HOME/tibco.home/bw*/*/ext/shared`/addons.link
 	# unzip whatever is there not done
@@ -171,7 +171,7 @@ checkLibs()
 {
 	BW_VERSION=`ls $HOME/tibco.home/bw*/`
 	libFolder=/resources/addons/lib
-	if [ "$(ls $libFolder)"  ]; then
+	if [ -d $libFolder ] && [ "$(ls $libFolder)" ]; then
 		print_Debug "Adding additional libs"
 		for name in $(find $libFolder -type f); 
 		do	
@@ -188,7 +188,7 @@ checkAgents()
 {
 	agentFolder=/resources/addons/monitor-agents
 
-	if [ "$(ls $agentFolder)"  ]; then 
+	if [ -d $agentFolder ] && [ "$(ls $agentFolder)" ]; then 
 		print_Debug "Adding monitoring jars"
 
 		for name in $(find $agentFolder -type f); 
@@ -222,7 +222,7 @@ then
 		checkAgents
 		checkLibs
 		jarFolder=/resources/addons/jars
-		if [ "$(ls $jarFolder)"  ]; then
+		if [ -d $jarFolder ] && [ "$(ls $jarFolder)" ]; then
 		#Copy jars to Hotfix
 	  		cp -r /resources/addons/jars/* `echo $HOME/tibco.home/bw*/*`/system/hotfix/shared
 		fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -151,7 +151,7 @@ checkJarsPalettes()
 BW_VERSION=`ls $HOME/tibco.home/bw*/`
 
 pluginFolder=/resources/addons/plugins
-if [ -d $pluginFolder ] && [ "$(ls $pluginFolder)" ]; then 
+if [ -d ${pluginFolder} ] && [ "$(ls $pluginFolder)" ]; then 
 	print_Debug "Adding Plug-in Jars"
 	echo -e "name=Addons Factory\ntype=bw6\nlayout=bw6ext\nlocation=$HOME/tibco.home/addons" > `echo $HOME/tibco.home/bw*/*/ext/shared`/addons.link
 	# unzip whatever is there not done
@@ -171,7 +171,7 @@ checkLibs()
 {
 	BW_VERSION=`ls $HOME/tibco.home/bw*/`
 	libFolder=/resources/addons/lib
-	if [ -d $libFolder ] && [ "$(ls $libFolder)" ]; then
+	if [ -d ${libFolder} ] && [ "$(ls $libFolder)" ]; then
 		print_Debug "Adding additional libs"
 		for name in $(find $libFolder -type f); 
 		do	
@@ -188,7 +188,7 @@ checkAgents()
 {
 	agentFolder=/resources/addons/monitor-agents
 
-	if [ -d $agentFolder ] && [ "$(ls $agentFolder)" ]; then 
+	if [ -d ${agentFolder} ] && [ "$(ls $agentFolder)" ]; then 
 		print_Debug "Adding monitoring jars"
 
 		for name in $(find $agentFolder -type f); 
@@ -222,7 +222,7 @@ then
 		checkAgents
 		checkLibs
 		jarFolder=/resources/addons/jars
-		if [ -d $jarFolder ] && [ "$(ls $jarFolder)" ]; then
+		if [ -d ${jarFolder} ] && [ "$(ls $jarFolder)" ]; then
 		#Copy jars to Hotfix
 	  		cp -r /resources/addons/jars/* `echo $HOME/tibco.home/bw*/*`/system/hotfix/shared
 		fi


### PR DESCRIPTION
This PR prevents ls from adding useless lines to the log output.