### PR TITLE
Fix for BWCE-1576 : Issue with netsuite plugin on docker with BWCE 2.3.3

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -200,7 +200,9 @@ checkPlugins()
 			if [[ "$(basename $name )" != .* ]]; then
 		   		unzip -q -o $name -d $BWCE_HOME/plugintmp/
 				mkdir -p $BWCE_HOME/tibco.home/addons/runtime/plugins/ && mv $BWCE_HOME/plugintmp/runtime/plugins/* "$_"
+				mkdir -p $BWCE_HOME/tibco.home/addons/lib/ && mv $BWCE_HOME/plugintmp/lib/* "$_"
 				mkdir -p $BWCE_HOME/tibco.home/addons/bin/ && mv $BWCE_HOME/plugintmp/bin/* "$_" 2> /dev/null || true
+				find  $BWCE_HOME/plugintmp//*  -type d ! \( -name "runtime" -o -name "bin" -o -name "lib" \)  -exec mv {} / \; 2> /dev/null
 				rm -rf $BWCE_HOME/plugintmp/
 				#mkdir -p $BWCE_HOME/tibco.home/addons/lib/ && mv lib/* "$_"/${name##*/}.ini
 			fi


### PR DESCRIPTION
Changes:

- Modified the checkPlugin function in setup.sh to copy the contents of lib folder in the plugin runtime zip to addons/lib

- Copying other folders to root location in order to handle  all the other folders besides "lib", "runtime" and "bin" in BW plugin runtime zip file.