### PR TITLE
Support for custom logback.xml

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -118,6 +118,17 @@ checkPolicy()
 setLogLevel()
 {
 	logback=$BWCE_HOME/tibco.home/bw*/*/config/logback.xml
+
+	if [[ ${CUSTOM_LOGBACK} ]]; then
+	         logback_custom=/resources/addons/custom-logback/logback.xml
+		 if [ -e ${logback_custom} ]; then
+			cp ${logback} `ls $logback`.original.bak && cp -f ${logback_custom}  ${logback}  
+			echo "Using Custom Logback file"
+		else
+			echo "Custom Logback file not found. Using the default logback file"
+		fi	
+	fi
+
 	if [[ ${BW_LOGLEVEL} && "${BW_LOGLEVEL,,}"="debug" ]]; then
 		if [ -e ${logback} ]; then
 			sed -i.bak "/<root/ s/\".*\"/\"$BW_LOGLEVEL\"/Ig" $logback
@@ -416,4 +427,6 @@ $JAVA_HOME/bin/java -cp `echo $BWCE_HOME/tibco.home/bw*/*/system/shared/com.tibc
 STATUS=$?
 if [ $STATUS == "1" ]; then
     exit 1 # terminate and indicate error
-fi
+f
+
+i

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -427,6 +427,4 @@ $JAVA_HOME/bin/java -cp `echo $BWCE_HOME/tibco.home/bw*/*/system/shared/com.tibc
 STATUS=$?
 if [ $STATUS == "1" ]; then
     exit 1 # terminate and indicate error
-f
-
-i
+fi


### PR DESCRIPTION
1. Made changes to be able to use custom logback.xml.
2. The custom logback.xml  file needs to be placed in the resources/addons/custom_logback folder and  should have the name logback.xml
3. If the environment variable CUSTOM_LOGBACK is provided, then this file would be used . The default logback file is backed up and the custom logback file is copied  and used instead of the default logback.xml.