### PR TITLE
Replaced MAINTAINER instruction with LABEL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:jessie-slim
-MAINTAINER TIBCO Software Inc.
+LABEL maintainer="TIBCO Software Inc."
 ADD . /
 RUN chmod 755 /scripts/*.sh && apt-get update && apt-get --no-install-recommends -y install unzip ssh net-tools && apt-get clean && rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["/scripts/start.sh"]

--- a/examples/HTTP/Dockerfile
+++ b/examples/HTTP/Dockerfile
@@ -1,5 +1,5 @@
 FROM bwce:v2.2.0.16
-MAINTAINER Vijay Nalawade <vnalawad@tibco.com>
+LABEL maintainer="Vijay Nalawade <vnalawad@tibco.com>"
 ADD docker.http.application_1.0.0.ear /
 EXPOSE 8080
 EXPOSE 8090


### PR DESCRIPTION
Replaced the deprecated MAINTAINER instruction with LABEL instruction  to set the maintainer. This would make the maintainer visible from docker inspect command along with other tags.