### PR TITLE
 Changes to run the BWCE docker containers as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,7 @@ FROM debian:stretch-slim
 LABEL maintainer="TIBCO Software Inc."
 ADD . /
 RUN chmod 755 /scripts/*.sh && apt-get update && apt-get --no-install-recommends -y install unzip ssh net-tools && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN groupadd -g 2001 bwce \
+&& useradd -r -u 2001 -g bwce bwce
+USER bwce
 ENTRYPOINT ["/scripts/start.sh"]


### PR DESCRIPTION
Made changes in the dockerfile to run the BWCE applications as a non-root user. Dockerfile has a value of UID 2001 and GID 2001 as default, this can be replaced with a another UID as per the requirement. 