### PR TITLE
Reduce startup time for container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM debian:stretch-slim
 LABEL maintainer="TIBCO Software Inc."
 ADD . /
 RUN chmod 755 /scripts/*.sh && apt-get update && apt-get --no-install-recommends -y install unzip ssh net-tools && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN unzip -qq /resources/bwce-runtime/bwce*.zip -d /tmp && rm -rf /resources/bwce-runtime/bwce*.zip 2> /dev/null
 ENTRYPOINT ["/scripts/start.sh"]

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -379,10 +379,8 @@ checkJAVAHOME
 checkJMXConfig
 checkJavaGCConfig
 
-if [ ! -d $BWCE_HOME/tibco.home ];
+if [ -d $BWCE_HOME/tibco.home ];
 then
-	unzip -qq /resources/bwce-runtime/bwce*.zip -d $BWCE_HOME
-	rm -rf /resources/bwce-runtime/bwce*.zip 2> /dev/null
 	chmod 755 $BWCE_HOME/tibco.home/bw*/*/bin/startBWAppNode.sh
 	chmod 755 $BWCE_HOME/tibco.home/bw*/*/bin/bwappnode
 	chmod 755 $BWCE_HOME/tibco.home/tibcojre64/*/bin/java


### PR DESCRIPTION
Added the updated Dockerfile and setup.sh script to reduce the container startup time by unzipping the runtime zip while creating the base image.  