### PR TITLE
Modified setup.sh to enable docker restart command for config management apps

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -409,12 +409,12 @@ then
 	unzip -qq `echo $BWCE_HOME/tibco.home/bw*/*/bin/bwapp.ear` -d /tmp
 	setLogLevel
 	memoryCalculator
-	checkEnvSubstituteConfig
 fi
 
 checkProfile
 checkPolicy
 setupThirdPartyInstallationEnvironment
+checkEnvSubstituteConfig
 
 if [ -f /*.substvar ]; then
 	cp -f /*.substvar $BWCE_HOME/tmp/pcf.substvar # User provided profile


### PR DESCRIPTION
This change has been made in the setup.sh file to enable the "docker restart" command for configuration management applications