### PR TITLE
Dynamic Memory Assignment 

### DIFF
--- a/reducedStartupTime/setup.sh
+++ b/reducedStartupTime/setup.sh
@@ -289,9 +289,33 @@ done
 
 memoryCalculator()
 {
-	if [[ ${MEMORY_LIMIT} ]]; then
-		memory_Number=`echo $MEMORY_LIMIT | sed 's/m$//I'`
-		configured_MEM=$((($memory_Number*67+50)/100))
+	if [[ ${MEMORY_LIMIT} ]]; then		
+
+		configured_MEM=$(expr `cat /sys/fs/cgroup/memory/memory.limit_in_bytes` / 1024 / 1024)
+		configured_MEM_orig=$configured_MEM
+
+		if [[ ${MEMORY_DYNAMIC_LIMIT} ]]; then			
+			sys_MEM=$(expr $configured_MEM \* ${MEMORY_DYNAMIC_LIMIT} / 100)
+			system_MEM=`printf "%.0f" $sys_MEM`
+			configured_MEM_temp=$(expr $configured_MEM - $system_MEM)
+			if [[  $configured_MEM_temp -gt 128 ]]; then
+				configured_MEM=$configured_MEM_temp
+			fi
+		elif [[ ${MEMORY_FIXED_LIMIT} ]]; then		
+			configured_MEM_temp=$(expr $configured_MEM - ${MEMORY_FIXED_LIMIT} )
+			if [[  $configured_MEM_temp -gt 128 ]]; then
+				configured_MEM=$configured_MEM_temp
+			fi
+		fi
+
+		if 	[[ $configured_MEM -eq $configured_MEM_orig ]]; then
+			configured_MEM_temp=$(expr $configured_MEM - 128)
+			if [[  $configured_MEM_temp -gt 128 ]]; then
+				configured_MEM=$configured_MEM_temp
+			fi
+		fi
+
+		print_Debug "Maximum memory calculated in a dynamic way to a value [$configured_MEM]"
 		thread_Stack=$((memory_Number))
 		JAVA_PARAM="-Xmx"$configured_MEM"M -Xms128M -Xss512K"
 		export BW_JAVA_OPTS=$JAVA_PARAM" "$BW_JAVA_OPTS

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -289,13 +289,37 @@ done
 
 memoryCalculator()
 {
-	if [[ ${MEMORY_LIMIT} ]]; then
-		memory_Number=`echo $MEMORY_LIMIT | sed 's/m$//I'`
-		configured_MEM=$((($memory_Number*67+50)/100))
+	if [[ ${MEMORY_LIMIT} ]]; then		
+
+		configured_MEM=$(expr `cat /sys/fs/cgroup/memory/memory.limit_in_bytes` / 1024 / 1024)
+		configured_MEM_orig=$configured_MEM
+
+		if [[ ${MEMORY_DYNAMIC_LIMIT} ]]; then			
+			sys_MEM=$(expr $configured_MEM \* ${MEMORY_DYNAMIC_LIMIT} / 100)
+			system_MEM=`printf "%.0f" $sys_MEM`
+			configured_MEM_temp=$(expr $configured_MEM - $system_MEM)
+			if [[  $configured_MEM_temp -gt 128 ]]; then
+				configured_MEM=$configured_MEM_temp
+			fi
+		elif [[ ${MEMORY_FIXED_LIMIT} ]]; then		
+			configured_MEM_temp=$(expr $configured_MEM - ${MEMORY_FIXED_LIMIT} )
+			if [[  $configured_MEM_temp -gt 128 ]]; then
+				configured_MEM=$configured_MEM_temp
+			fi
+		fi
+
+		if 	[[ $configured_MEM -eq $configured_MEM_orig ]]; then
+			configured_MEM_temp=$(expr $configured_MEM - 128)
+			if [[  $configured_MEM_temp -gt 128 ]]; then
+				configured_MEM=$configured_MEM_temp
+			fi
+		fi
+
+		print_Debug "Maximum memory calculated in a dynamic way to a value [$configured_MEM]"
 		thread_Stack=$((memory_Number))
 		JAVA_PARAM="-Xmx"$configured_MEM"M -Xms128M -Xss512K"
 		export BW_JAVA_OPTS=$JAVA_PARAM" "$BW_JAVA_OPTS
-	fi	
+	fi
 }
 
 applyDefaultJVMHeapParams(){


### PR DESCRIPTION
Included the option to set the Xmx based on the configured memory to the container. It uses the introduce new variable MEMORY_LIMIT that wasn't in use at the moment, using the following approach.

- We get the amount of memory reserved for the container and substract a little bit for the rest of the container and everyhing else is set as Xmx. We have two way to set the amount of memory that is going to use for the system (not BW) based on variables:
    - MEMORY_FIXED_LIMIT (in MB): in case you want to substract a fixed amount of memory like 128 or similar.
    - MEMORY_DYAMIC_LIMIT in (percentage from 0-100): in case you want to substract a percentage of the assigned memory.

In both cases if the memory that is dedicated is less than 128 M it is ignored and use a failsafe memory (memory assigned - 128). IN case only MEMORY_LIMIT is set, do same thing (memory assigned - 128)

Also added a DEBUG trace that shows the amount of memory that is going to be assigned: