### PR TITLE
Fix to create user home directory and handle additional plugin folders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ LABEL maintainer="TIBCO Software Inc."
 ADD . /
 RUN chmod 755 /scripts/*.sh && apt-get update && apt-get --no-install-recommends -y install unzip ssh net-tools && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN groupadd -g 2001 bwce \
-&& useradd -r -u 2001 -g bwce bwce
+&& useradd -m -d /home/bwce -r -u 2001 -g bwce bwce
 USER bwce
 ENTRYPOINT ["/scripts/start.sh"]

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -214,7 +214,7 @@ checkPlugins()
 				mkdir -p $BWCE_HOME/tibco.home/addons/lib/ && mv $BWCE_HOME/plugintmp/lib/*.ini "$_"${name##*/}.ini
 				mkdir -p $BWCE_HOME/tibco.home/addons/lib/ && mv $BWCE_HOME/plugintmp/lib/*.jar "$_" 2> /dev/null || true
 				mkdir -p $BWCE_HOME/tibco.home/addons/bin/ && mv $BWCE_HOME/plugintmp/bin/* "$_" 2> /dev/null || true
-				find  $BWCE_HOME/plugintmp/*  -type d ! \( -name "runtime" -o -name "bin" -o -name "lib" \)  -exec mv {} / \; 2> /dev/null
+				find  $BWCE_HOME/plugintmp/*  -type d ! \( -name "runtime" -o -name "bin" -o -name "lib" \)  -exec mv {} /tmp \; 2> /dev/null
 				rm -rf $BWCE_HOME/plugintmp/
 			fi
 		done


### PR DESCRIPTION
-  Added the change to create the user home directory for the default non-root user by providing the '-m' option for useradd

- Instead of copying the additional folders in plugin runtime zip to root location, it is now being copied to /tmp
