### PR TITLE
Removed redundant statement after exec command in bwappnode file.

### DIFF
--- a/reducedStartupTime/setup.sh
+++ b/reducedStartupTime/setup.sh
@@ -476,7 +476,6 @@ then
 		
 	#TODO: check without tra modification
 	#Modify bwappnode & bwappnode.tra file in runtime zip
-	echo -e "\nexport TIBCO_JAVA_HOME=${tci_java_home} \ntibco.include.tra=${TCI_HOME}/bin/bwcommon.tra" >> bwappnode
 	sed -i "s+$APPDIR/tibco.home+/opt/tibco+g" bwappnode
 	sed -i "s+bwce/${BW_VERSION}+bwcloud/${CLOUD_VERSION}+g" bwappnode 
 	


### PR DESCRIPTION
In bwappnode file, this statement was appending env variables after the "java exec" statement was executed. As a result, data that was being appended after the exec statement was not getting applied. 

In order to append data before the exec statement, we need to remove this statement. 

Furthermore,  the variables being set by the echo statement are not being used in TCI-BW, hence, redundant. 