### PR TITLE
Memlimit

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -301,15 +301,17 @@ done
 }
 
 memoryCalculator()
-{
-	if [[ ${MEMORY_LIMIT} ]]; then
-		memory_Number=`echo $MEMORY_LIMIT | sed 's/m$//I'`
-		configured_MEM=$((($memory_Number*67+50)/100))
-		thread_Stack=$((memory_Number))
-		JAVA_PARAM="-Xmx"$configured_MEM"M -Xms128M -Xss512K"
-		export BW_JAVA_OPTS=$JAVA_PARAM" "$BW_JAVA_OPTS
-	fi	
+{		
+		MEM_LIMIT=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+		if [ $MEM_LIMIT -ne 9223372036854771712 ] && [ $MEM_LIMIT -gt 0 ] ; then
+			memory_Number=$(expr $MEM_LIMIT / 1024 / 1024)
+			configured_MEM=$((($memory_Number*67+50)/100))
+			thread_Stack=$((memory_Number))
+			JAVA_PARAM="-Xmx"$configured_MEM"M -Xms128M -Xss512K"
+			export BW_JAVA_OPTS=$JAVA_PARAM" "$BW_JAVA_OPTS
+		fi
 }
+
 
 applyDefaultJVMHeapParams(){
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -302,14 +302,14 @@ done
 
 memoryCalculator()
 {		
-		MEM_LIMIT=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
-		if [ $MEM_LIMIT -ne 9223372036854771712 ] && [ $MEM_LIMIT -gt 0 ] ; then
-			memory_Number=$(expr $MEM_LIMIT / 1024 / 1024)
-			configured_MEM=$((($memory_Number*67+50)/100))
-			thread_Stack=$((memory_Number))
-			JAVA_PARAM="-Xmx"$configured_MEM"M -Xms128M -Xss512K"
-			export BW_JAVA_OPTS=$JAVA_PARAM" "$BW_JAVA_OPTS
-		fi
+	MEM_LIMIT=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+	if [ $MEM_LIMIT -ne 9223372036854771712 ] && [ $MEM_LIMIT -gt 0 ] ; then
+		memory_Number=$(expr $MEM_LIMIT / 1024 / 1024)
+		configured_MEM=$((($memory_Number*67+50)/100))
+		thread_Stack=$((memory_Number))
+		JAVA_PARAM="-Xmx"$configured_MEM"M -Xms128M -Xss512K"
+		export BW_JAVA_OPTS=$JAVA_PARAM" "$BW_JAVA_OPTS
+	fi
 }
 
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -312,7 +312,6 @@ memoryCalculator()
 	fi
 }
 
-
 applyDefaultJVMHeapParams(){
 
 	DEFAULT_JVM_HEAP_PARAMS="-Xmx1024M -Xms128M"


### PR DESCRIPTION
Currently we have an environment variable “MEMORY_LIMIT” which we use to calculate max heap dynamically but Docker also provides an option to set the memory limit and BWCE app is unaware of this setting and JVM heap size is set to default 1024MB even though container memory is limited to a smaller value.

When the container memory limit is set through the memory flag, we can find this value from sys/fs/cgroup/memory/memory.limit_in_bytes and we can use this value in our calculation.

When the memory limit is not set, the value of sys/fs/cgroup/memory/memory.limit_in_bytes is 9223372036854771712(maximum 64-bit signed integer, rounded to the nearest page) and can be -1 if it is memory limiting is disabled. Added a condition to check this and only calculate the heap size dynamically when the memory limit is set using the memory flag.