### PR TITLE
 Changes to make UTL-8 locale as default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,6 @@ RUN chmod 755 /scripts/*.sh && apt-get update && apt-get --no-install-recommends
 RUN groupadd -g 2001 bwce \
 && useradd -m -d /home/bwce -r -u 2001 -g bwce bwce
 USER bwce
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
 ENTRYPOINT ["/scripts/start.sh"]


### PR DESCRIPTION
Currently the locale inside the container is POSIX. This causes problems with some of the characters used/passed as environment variables. Made changes to make UTF-8 as default