### PR TITLE
Ensure Unzip for the second plugin has a valid plugintmp folder

### DIFF
--- a/reducedStartupTime/setup.sh
+++ b/reducedStartupTime/setup.sh
@@ -254,7 +254,7 @@ checkPlugins()
 					find  $BWCE_HOME/plugintmp/*  -type d ! \( -name "runtime" -o -name "bin" -o -name "lib" \)  -exec mv {} /opt/tibco \; 2> /dev/null
 				fi
 				rm -rf $BWCE_HOME/plugintmp/
-				mkdir -p $BWCE_HOME/plugintmp
+				mkdir $BWCE_HOME/plugintmp
 			fi
 		done
 	fi

--- a/reducedStartupTime/setup.sh
+++ b/reducedStartupTime/setup.sh
@@ -254,6 +254,7 @@ checkPlugins()
 					find  $BWCE_HOME/plugintmp/*  -type d ! \( -name "runtime" -o -name "bin" -o -name "lib" \)  -exec mv {} /opt/tibco \; 2> /dev/null
 				fi
 				rm -rf $BWCE_HOME/plugintmp/
+				mkdir -p $BWCE_HOME/plugintmp
 			fi
 		done
 	fi


### PR DESCRIPTION
There is a issue where second Plugin would fail to unzip because "plugintmp" folder is missing after the "rm" command.  You would get an error at line 246.