### PR TITLE
Fix for https://jira.tibco.com/browse/BWCE-5828

### DIFF
--- a/reducedStartupTime/Dockerfile
+++ b/reducedStartupTime/Dockerfile
@@ -1,11 +1,6 @@
 #Use this dockerfile to unzip the bwce-runtime zip while creating the base image.
-FROM debian:stretch-slim
+FROM eclipse-temurin:11-alpine
 LABEL maintainer="TIBCO Software Inc."
 ADD . /
-RUN chmod 755 /scripts/*.sh && apt-get update && apt-get --no-install-recommends -y install unzip ssh net-tools && apt-get clean && rm -rf /var/lib/apt/lists/*
-RUN groupadd -g 2001 bwce \
-&& useradd -r -u 2001 -g bwce bwce
-RUN unzip -qq /resources/bwce-runtime/bwce*.zip -d /tmp && rm -rf /resources/bwce-runtime/bwce*.zip 2> /dev/null
-RUN chown -R bwce:bwce /tmp
-USER bwce
+RUN chmod 755 /scripts/*.sh && apk update && apk add unzip openssh net-tools && apk add --no-cache bash
 ENTRYPOINT ["/scripts/start.sh"]


### PR DESCRIPTION
Fix for https://jira.tibco.com/browse/BWCE-5828: [GitHub commits] Review and update all scripts/files under bwce-docker GH repo openjdk-alpine.