### PR TITLE
Fix for https://jira.tibco.com/browse/BWCE-5347

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 LABEL maintainer="TIBCO Software Inc."
 ADD . /
 RUN chmod 755 /scripts/*.sh && apt-get update && apt-get --no-install-recommends -y install unzip ssh net-tools && apt-get -y install xsltproc && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/reducedStartupTime/Dockerfile
+++ b/reducedStartupTime/Dockerfile
@@ -1,5 +1,5 @@
 #Use this dockerfile to unzip the bwce-runtime zip while creating the base image.
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 LABEL maintainer="TIBCO Software Inc."
 ADD . /
 RUN chmod 755 /scripts/*.sh && apt-get update && apt-get --no-install-recommends -y install unzip ssh net-tools && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/reducedStartupTime/setup.sh
+++ b/reducedStartupTime/setup.sh
@@ -18,7 +18,7 @@ echo "INFO Variables received :" $TCI_BW_EDITION, $TCI_HOME, $CLOUD_VERSION, $BW
 
 print_Debug()
 {
-		if [[ ${BW_LOGLEVEL} && "${BW_LOGLEVEL,,}"="debug" ]]; then
+		if [[ ${BW_LOGLEVEL} && "${BW_LOGLEVEL,,}" = "debug" ]]; then
  			echo $1 
  		fi
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,7 +10,7 @@
 
 print_Debug()
 {
-		if [[ ${BW_LOGLEVEL} && "${BW_LOGLEVEL,,}"="debug" ]]; then
+		if [[ ${BW_LOGLEVEL} && "${BW_LOGLEVEL,,}" = "debug" ]]; then
  			echo $1 
  		fi
 }


### PR DESCRIPTION
Fix for https://jira.tibco.com/browse/BWCE-5347: Upgrade "debian:bullseye-slim" base image to "debian:bookworm" base image.