### PR TITLE
Updated base image to debian:trixie-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS builder
+FROM debian:trixie-slim AS builder
 LABEL maintainer="Cloud Software Group, Inc."
 WORKDIR /app
 COPY . .
@@ -12,7 +12,7 @@ ARG EXCLUDE_JDBC=false
 RUN chmod 755 /app/scripts/*.sh && /app/scripts/customize-runtime.sh
 
 #final stage
-FROM debian:bookworm-slim AS final
+FROM debian:trixie-slim AS final
 LABEL maintainer="Cloud Software Group, Inc."
 COPY --from=builder /app/resources  /resources
 COPY --from=builder /app/scripts /scripts

--- a/reducedStartupTime/Dockerfile
+++ b/reducedStartupTime/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS builder
+FROM debian:trixie-slim AS builder
 LABEL maintainer="Cloud Software Group, Inc."
 WORKDIR /app
 COPY . .
@@ -13,7 +13,7 @@ ARG EXCLUDE_JDBC=false
 RUN  /app/scripts/customize-runtime.sh
 
 #final stage
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 LABEL maintainer="Cloud Software Group, Inc."
 RUN apt-get update && apt-get --no-install-recommends -y install unzip && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN groupadd -g 2001 bwce && useradd -m -d /home/bwce -r -u 2001 -g bwce bwce


### PR DESCRIPTION
Updates the Debian base image from `bookworm-slim` (Debian 12) to `trixie-slim` (Debian 13) across both build stages of `Dockerfile` and `reducedStartupTime/Dockerfile`.

Jira: BWCE-11831 (fixVersion 6.12.0 HF4)

## Changes

| File | Stage | From | To |
|---|---|---|---|
| `Dockerfile` | builder | `debian:bookworm-slim` | `debian:trixie-slim` |
| `Dockerfile` | final | `debian:bookworm-slim` | `debian:trixie-slim` |
| `reducedStartupTime/Dockerfile` | builder | `debian:bookworm-slim` | `debian:trixie-slim` |
| `reducedStartupTime/Dockerfile` | final | `debian:bookworm-slim` | `debian:trixie-slim` |

Four `FROM` lines; no other content changed. `git grep bookworm` now returns nothing.

## Note on scope

BWCE-11831 names only `Dockerfile`. `reducedStartupTime/Dockerfile` is included so the
repo does not straddle two Debian releases — flagging it explicitly for the reviewer.

## Testing

Not build-verified in this change. The Dockerfile-level change is low risk — `unzip`,
`zip` and `passwd` (`groupadd`/`useradd`) are all still present in trixie. The real risk
is the BWCE runtime's own expectations: Debian 12 → 13 moves glibc 2.36 → 2.41 and
OpenSSL 3.0 → 3.5.

Suggested verification before this ships in 6.12.0 HF4:

1. Build the base image with a BWCE runtime ZIP present in the build context.
2. Build an application image from it and start the container; confirm the AppNode
   comes up and the app reaches Running.
3. Smoke-test a TLS-dependent flow (HTTPS or JDBC over TLS) to exercise OpenSSL 3.5.
4. Repeat 1–3 for the `reducedStartupTime` variant.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
